### PR TITLE
Boost process priority during fork.

### DIFF
--- a/core/jni/com_android_internal_os_Zygote.cpp
+++ b/core/jni/com_android_internal_os_Zygote.cpp
@@ -2279,6 +2279,11 @@ pid_t zygote::ForkCommon(JNIEnv* env, bool is_system_server,
                          const std::vector<int>& fds_to_ignore,
                          bool is_priority_fork,
                          bool purge) {
+  ATRACE_CALL();
+  if (is_priority_fork) {
+    setpriority(PRIO_PROCESS, 0, PROCESS_PRIORITY_MAX);
+  }
+
   SetSignalHandlers();
 
   // Curry a failure function.
@@ -2364,6 +2369,10 @@ pid_t zygote::ForkCommon(JNIEnv* env, bool is_system_server,
   // We blocked SIGCHLD prior to a fork, we unblock it here.
   UnblockSignal(SIGCHLD, fail_fn);
 
+  if (is_priority_fork && pid != 0) {
+    setpriority(PRIO_PROCESS, 0, PROCESS_PRIORITY_DEFAULT);
+  }
+
   return pid;
 }
 
@@ -2431,6 +2440,7 @@ static jint com_android_internal_os_Zygote_nativeForkSystemServer(
         JNIEnv* env, jclass, uid_t uid, gid_t gid, jintArray gids,
         jint runtime_flags, jobjectArray rlimits, jlong permitted_capabilities,
         jlong effective_capabilities) {
+  ATRACE_CALL();
   std::vector<int> fds_to_close(MakeUsapPipeReadFDVector()),
                    fds_to_ignore(fds_to_close);
 
@@ -2506,6 +2516,7 @@ static jint com_android_internal_os_Zygote_nativeForkApp(JNIEnv* env,
                                                          jintArray managed_session_socket_fds,
                                                          jboolean args_known,
                                                          jboolean is_priority_fork) {
+  ATRACE_CALL();
   std::vector<int> session_socket_fds =
       ExtractJIntArray(env, "USAP", nullptr, managed_session_socket_fds)
           .value_or(std::vector<int>());
@@ -2521,6 +2532,7 @@ int zygote::forkApp(JNIEnv* env,
                     bool args_known,
                     bool is_priority_fork,
                     bool purge) {
+  ATRACE_CALL();
 
   std::vector<int> fds_to_close(MakeUsapPipeReadFDVector()),
                    fds_to_ignore(fds_to_close);


### PR DESCRIPTION
The zygote process sets MAX priority for the child process after a fork if it is a 'high priority fork' (e.g. for top-app). However, the zygote does a fair amount of work before the fork, and can take up some amount of time due to getting descheduled. This introduces latency in app-launch, especially on low-power devices.

Fix this by setting the zygote process priority to MAX for a high-priority fork early on, and reset it back to DEFAULT afterwards.

Bug: 323891634
Test: manually
Change-Id: Iac1ea81531f59ee6245c73530f2dd639209421f7